### PR TITLE
Allow flags to be overriden by the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CFLAGS := -O
-CPPFLAGS :=
-LDLIBS := -lm
+CFLAGS ?= -O
+CPPFLAGS ?=
+LDLIBS ?= -lm
 
 .PHONY: target
 target: symmetry.x check


### PR DESCRIPTION
Change flags assignments in the Makefile from := to ?=, so that environment variables can override them