### PR TITLE
Implement `install` target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 CFLAGS ?= -O -Wall -Werror
 CPPFLAGS ?=
 LDLIBS ?= -lm
+PREFIX ?= /usr/local
+INSTALL_TARGET_DIR := $(DESTDIR)$(PREFIX)/bin
 
 .PHONY: target
 target: symmetry.x check
@@ -15,3 +17,10 @@ check: symmetry.x
 .PHONY: clean
 clean:
 	rm -f symmetry.x
+
+$(INSTALL_TARGET_DIR):
+	mkdir -p "$@"
+
+.PHONY: install
+install: symmetry.x $(INSTALL_TARGET_DIR)
+	install -m 755 "$<" "$(INSTALL_TARGET_DIR)/$<"


### PR DESCRIPTION
By default `make install` installs `symmetry.x` to `/usr/local/bin`. `PREFIX` and `DESTDIR` variables with Autotools-like semantics are respected.